### PR TITLE
Fix rate counting

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,13 @@ The released binary is expected to run in containers or linux-like hosts of `amd
 For Windows 10+ environments you can run it in  WSL2.
 For other environments, please build your version from sources.
 
-### Get the pre-build extended K6 binary
+### Build K6 binary
 
-- Find the [latest release}(https://github.com/mdsol/xk6-output-otlp/releases).
-- Download `k6.tar.gz` archive, and extract the `k6` binary with
+You should have `Go 1.22+` and `make` installed.
 
-  ```sh
-  tar -xvzf k6.tar.gz
-  ```
+- clone the [repository](https://github.com/mdsol/xk6-output-otlp) using git;
+- run `make build`;
+- the `k6` binary is in the project's `./bin` subfolder.
 
 ### Configuration
 
@@ -71,7 +70,7 @@ If `<name>` is a name of the original rate metric, it produces:
 
 - `k6_<name>_total` OTLP counter which contains the total number of occurrences;
 - `k6_<name>_success_total` OTLP counter which contains the total number of successful occurrences;
-- `k6_<name>_success_rate` OTLP Gauge, which contains the pre-computed rate. 
+- `k6_<name>_success_rate` OTLP Gauge, which contains the pre-computed rate over the whole metric family. 
 
 The latest pre-computed rate value should match appropriate K6 output.
 

--- a/pkg/otlp/rates.go
+++ b/pkg/otlp/rates.go
@@ -5,19 +5,19 @@ import (
 )
 
 type rate struct {
-	sum   float64
-	count float64
+	sum     float64
+	counter float64
 }
 
 func (r *rate) value() float64 {
-	if r.count == 0 {
+	if r.counter == 0 {
 		return 0
 	}
-	return r.sum / r.count
+	return r.sum / r.counter
 }
 
 func (r *rate) combine(sample *k6m.Sample) float64 {
-	r.count += 1.0
+	r.counter += 1.0
 	r.sum += sample.Value
 	return r.value()
 }

--- a/pkg/otlp/wraprate.go
+++ b/pkg/otlp/wraprate.go
@@ -42,7 +42,9 @@ type rateWrapper struct {
 func (w *rateWrapper) Record(s *k6m.Sample) {
 	attrs := om.WithAttributes(attributes(s.TimeSeries.Tags)...)
 
-	w.metricRate.Record(params.ctx, w.rate.combine(s))
+	// Here we count rate ove whole metric family as we see the result in the K6 output.
+	w.metricRate.Record(params.ctx, w.rate.combine(s), om.WithAttributes(sessionAttrs...))
+
 	w.metricTotal.Add(params.ctx, 1, attrs)
 	w.metricSuccess.Add(params.ctx, int64(math.Floor(s.Value)), attrs)
 }

--- a/pkg/otlp/wraprate.go
+++ b/pkg/otlp/wraprate.go
@@ -8,7 +8,7 @@ import (
 )
 
 func newRateWrapper(id int, name string) (Wrapper, error) {
-	metricTotal, err := meter.Int64Counter(name)
+	metricTotal, err := meter.Int64Counter(name + "_total")
 	if err != nil {
 		return nil, err
 	}
@@ -42,10 +42,7 @@ type rateWrapper struct {
 func (w *rateWrapper) Record(s *k6m.Sample) {
 	attrs := om.WithAttributes(attributes(s.TimeSeries.Tags)...)
 
-	w.metricRate.Record(params.ctx, w.rate.combine(s), attrs)
-	w.metricTotal.Add(params.ctx, int64(math.Floor(s.Value)))
-
-	if s.Value == 1 {
-		w.metricSuccess.Add(params.ctx, int64(math.Floor(s.Value)), attrs)
-	}
+	w.metricRate.Record(params.ctx, w.rate.combine(s))
+	w.metricTotal.Add(params.ctx, 1, attrs)
+	w.metricSuccess.Add(params.ctx, int64(math.Floor(s.Value)), attrs)
 }

--- a/pkg/otlp/wraprate.go
+++ b/pkg/otlp/wraprate.go
@@ -42,7 +42,7 @@ type rateWrapper struct {
 func (w *rateWrapper) Record(s *k6m.Sample) {
 	attrs := om.WithAttributes(attributes(s.TimeSeries.Tags)...)
 
-	// Here we count rate ove whole metric family as we see the result in the K6 output.
+	// Here we count rate over whole metric family as we see the result in the K6 output.
 	w.metricRate.Record(params.ctx, w.rate.combine(s), om.WithAttributes(sessionAttrs...))
 
 	w.metricTotal.Add(params.ctx, 1, attrs)


### PR DESCRIPTION
- rate counting fixed;
- due to my migration to Mac, the binaries I have generated can't work in a typical Linux container, so I should not add them to the release binaries. Instead of this, a GHA for release binary generation should be added, which is out of the PR scope.
- README updated.